### PR TITLE
Compatibility with archlinux, and installing (instead of running from repo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 .venv
 *.egg-info
 __pycache__
-memory_analyzer/templates/rendered_template*.out
 htmlcov
 dist
 build
 .tox
+memory_analyzer_out

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,10 @@ release:
 	rm -r dist
 	python3 setup.py sdist bdist_wheel
 	twine upload dist/*
+
+# Run this via 'tox -e integration' -- this verifies that templates are
+# packaged, and that nothing is leaking through from the repo.
+.PHONY: integrationtest
+integrationtest:
+	which memory_analyzer
+	python3 -m unittest memory_analyzer.integrationtest

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ setup:
 .PHONY: test
 test:
 	python3 -m coverage run -m memory_analyzer.tests
-	python3 -m coverage report --omit='.venv/*' --show-missing
+	python3 -m coverage report --omit='.venv/*,.tox/*' --show-missing
 
 .PHONY: format
 format:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ special debugging code or flags. Running the analysis will not (*cough* should n
 your process, although your process (and all of its threads!) will be paused while
 the memory analyzer gathers information about the objects in memory.
 
+You will need to install objgraph and pympler in the target binary's library
+path, in addition to the deps in `requirements*.txt` for running the frontend.
+
 ## License
 
 This source code is licensed under the MIT license. Please see the LICENSE in the root directory for more information. 
@@ -46,11 +49,20 @@ This source code is licensed under the MIT license. Please see the LICENSE in th
 
 This will put you into an ncurses UI and make a binary output file located in `memory_analyzer_out/memory_analyzer_snapshot-{TIMESTAMP}`
 
-If you are analyzing a process that was run as root, you may need to run the analyzer as root as well.
+If you are analyzing a process that was run as root, you need to run the analyzer as root as well.
 
-### Running on Ubuntu
+### Running on a modern ptrace-limited system
 
-In Maverick Meerkat (10.10) Ubuntu introduced a patch that disallows ptracing of non-child processes by non-root users. You can either look into disabling this restriction, or run the analyzer as root.
+Modern versions of at least Ubuntu and Arch have a patch that disallows ptracing
+of non-child processes by non-root users.
+
+You can disable this using
+
+```
+echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+```
+
+or run `memory_analyzer` as root.
 
 
 ## View the Output without Re-Analyzing

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This is an error from GDB itself, and it could mean a couple of things:
 1. You don't have the correct debuginfo installed, or
 2. You are using the wrong Python executable. 
 
-To fix the incorrect debuginf install the debuginfo associated with the python runtime the analyzed process is using. For example:
+To fix the incorrect debuginfo install the debuginfo associated with the python runtime the analyzed process is using. For example:
     
     sudo yum install python3-debuginfo
 

--- a/memory_analyzer/frontend/__init__.py
+++ b/memory_analyzer/frontend/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/memory_analyzer/integrationtest.py
+++ b/memory_analyzer/integrationtest.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+class IntegrationTest(unittest.TestCase):
+    def test_works_at_all(self):
+        output_name = tempfile.mktemp()
+        print(output_name)
+
+        # This tells us that everything important was packaged if we tox
+        # installed an sdist, but doesn't tell us anything if this was setup.py
+        # develop'd in a git repo.
+        os.chdir("/")
+
+        self.assertFalse(os.path.exists(output_name))
+        with open("/proc/sys/kernel/yama/ptrace_scope") as f:
+            value = f.read().strip()
+
+        self.assertEqual("0", value, "/proc/sys/kernel/yama/ptrace_scope should be 0")
+
+        # Presumably this is a virtualenv python executable that has objgraph
+        # and pympler
+        try:
+            child = subprocess.Popen(
+                [sys.executable, "-c", "import sys; sys.stdin.readline()"],
+                stdin=subprocess.PIPE,
+            )
+            # TODO figure out how we can ensure setup is done; right now we're
+            # just relying on it taking a while to launch/attach
+            analyzer = subprocess.Popen(
+                ["memory_analyzer", "run", "-q", "-f", output_name, str(child.pid)]
+            )
+            rc = analyzer.wait(5)
+        finally:
+            child.communicate(b"\n")
+
+        self.assertEqual(0, rc)
+        self.assertTrue(os.path.exists(output_name))
+        # TODO verify pickle has some strs
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/memory_analyzer/templates/analysis.py.template
+++ b/memory_analyzer/templates/analysis.py.template
@@ -82,6 +82,7 @@ try:
       pickle.dump(summ, fifo)
 
 except Exception as e:
+    print("Got exception", e)
     import pickle
     # We don't want exceptions here to affect the profiled process but want to
     # see the exceptions in the UI

--- a/memory_analyzer/tests/test_analysis_utils.py
+++ b/memory_analyzer/tests/test_analysis_utils.py
@@ -15,11 +15,15 @@ from .. import analysis_utils
 
 class AnalysisUtilsTest(TestCase):
     PID = 123
-    CURRENT_PATH = os.path.abspath(os.path.dirname(sys.argv[0]))
+    CURRENT_PATH = os.path.abspath(f"{os.path.dirname(__file__)}/..")
 
     def setUp(self):
-        self.gdb = analysis_utils.GDBObject(self.PID, self.CURRENT_PATH, sys.executable)
-        self.filepath = f"{self.CURRENT_PATH}/gdb_commands.py"
+        self.gdb = analysis_utils.GDBObject(
+            self.PID, self.CURRENT_PATH, sys.executable, "/tmp"
+        )
+        self.filepath = os.path.abspath(
+            f"{os.path.dirname(__file__)}/../gdb_commands.py"
+        )
         self.executable = sys.executable
         # Swallow the info messages
         patch_info = mock.patch("memory_analyzer.frontend.frontend_utils.echo_info")

--- a/memory_analyzer/tests/test_gdb_commands.py
+++ b/memory_analyzer/tests/test_gdb_commands.py
@@ -40,8 +40,8 @@ class GdbCommandsTests(TestCase):
         )
         wrap = gdb_commands.lock_GIL(func)
         wrap()
-        call_1 = "call PyGILState_Ensure()"
-        call_2 = "call PyGILState_Release($2)"
+        call_1 = "call (void*) PyGILState_Ensure()"
+        call_2 = "call (void) PyGILState_Release($2)"
         mock_calls = [mock.call(call_1, to_string=True), mock.call(call_2)]
         mock_gdb.execute.assert_has_calls(mock_calls)
         mock_write.assert_has_calls([mock.call("$2"), mock.call("\n")])
@@ -52,8 +52,8 @@ class GdbCommandsTests(TestCase):
         mock_gdb.execute.return_value = "[New Thread 0x7f48e4dd7700 (LWP 2640572)]"
         wrap = gdb_commands.lock_GIL(func)
         wrap()
-        call_1 = "call PyGILState_Ensure()"
-        call_2 = "call PyGILState_Release($1)"
+        call_1 = "call (void*) PyGILState_Ensure()"
+        call_2 = "call (void) PyGILState_Release($1)"
         mock_calls = [mock.call(call_1, to_string=True), mock.call(call_2)]
         mock_gdb.execute.assert_has_calls(mock_calls)
         mock_write.assert_has_calls([mock.call("$1"), mock.call("\n")])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py36, py37, py38
+envlist = py36, py37, py38, integration
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -8,3 +8,7 @@ commands =
     make test
 setenv =
     py{36,37,38}: COVERAGE_FILE={envdir}/.coverage
+
+[testenv:integration]
+commands =
+    make integrationtest

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     ],
     license="MIT",
     packages=find_packages(),
+    package_data={"memory_analyzer": ["templates/*.template"]},
     test_suite="memory_analyzer.tests",
     python_requires=">=3.6",
     setup_requires=["setuptools"],


### PR DESCRIPTION
- move rendered templates to tmpdir
- don't rely on argv[0] anymore
- provide return types for GIL operations to work w/o full debug symbols
- add integration test tox env that should catch these in the future