### PR TITLE
Moves .png files into output folder.

### DIFF
--- a/memory_analyzer/analysis_utils.py
+++ b/memory_analyzer/analysis_utils.py
@@ -168,12 +168,12 @@ def render_template(
     num_refs,
     pid,
     specific_refs,
-    output_file,
+    output_path,
     template_out_dir,
 ):
     objgraph_template = load_template(template_name, templates_path)
     template = objgraph_template.render(
-        num_refs=num_refs, pid=pid, specific_refs=specific_refs, output_file=output_file
+        num_refs=num_refs, pid=pid, specific_refs=specific_refs, output_path=output_path
     )
     # This path has to match the end of gdb_commands.py; the env var is set in
     # GDBObject constructor above.

--- a/memory_analyzer/memory_analyzer.py
+++ b/memory_analyzer/memory_analyzer.py
@@ -28,13 +28,14 @@ def analyze_memory_launcher(
     )
     cur_path = os.path.dirname(__file__) + "/"  # not zip safe, for now
     gdb_obj = analysis_utils.GDBObject(pid, cur_path, executable, template_out_path)
+    output_path = os.path.abspath(output_file)
     analysis_utils.render_template(
         f"analysis.py.template",
         templates_path,
         num_refs,
         pid,
         specific_refs,
-        output_file,
+        output_path,
         template_out_path,
     )
     return gdb_obj.run_analysis(debug)

--- a/memory_analyzer/templates/analysis.py.template
+++ b/memory_analyzer/templates/analysis.py.template
@@ -58,7 +58,7 @@ try:
       obj = sublist[0]
       obj_shortname = obj.split('.')[-1]
       obj_shortname = re.sub("[^A-Za-z0-9._]+", "", obj_shortname)
-      dirname = os.path.dirname(os.path.abspath("{{ output_file }}"))
+      dirname = os.path.dirname("{{ output_path }}")
       with SwallowPrints():
           forw = forward_references(dirname, obj, obj_shortname)
           back = backwards_references(dirname, obj, obj_shortname)

--- a/memory_analyzer/tests/test_analysis_template.py
+++ b/memory_analyzer/tests/test_analysis_template.py
@@ -58,13 +58,14 @@ class ObjGraphTemplateTests(TestCase):
     @mock.patch.object(objgraph, "show_backrefs")
     @mock.patch.object(objgraph, "show_refs")
     def test_with_num_references(self, mock_refs, mock_back_refs):
+        dirname = "/tmp/tests/"
         template = analysis_utils.render_template(
             self.template_name,
             self.templates_path,
             1,
             self.pid,
             [],
-            self.filename,
+            f"{dirname}{self.filename}",
             None,
         )
         with mock.patch("builtins.open", mock.mock_open(), create=True) as mock_fifo:
@@ -72,7 +73,6 @@ class ObjGraphTemplateTests(TestCase):
         handler = mock_fifo()
         output_bytes = pickle.dumps(self.items)
         handler.write.assert_called_with(output_bytes)
-        dirname = os.path.dirname(os.path.abspath(self.filename))
         self.assertEqual(
             self.items,
             [
@@ -80,8 +80,8 @@ class ObjGraphTemplateTests(TestCase):
                     "builtins.test1",
                     1,
                     10000,
-                    f"{dirname}/ref_1234_test1.png",
-                    f"{dirname}/backref_1234_test1.png",
+                    f"{dirname}ref_1234_test1.png",
+                    f"{dirname}backref_1234_test1.png",
                 ],
                 ["ast._things.test3", 10, 1024],
                 ["__main__.test2", 3, 5],
@@ -91,6 +91,7 @@ class ObjGraphTemplateTests(TestCase):
     @mock.patch.object(objgraph, "show_backrefs")
     @mock.patch.object(objgraph, "show_refs")
     def test_with_specific_references(self, mock_refs, mock_back_refs):
+        dirname = "/tmp/tests/"
         with tempfile.TemporaryDirectory() as d:
             template = analysis_utils.render_template(
                 self.template_name,
@@ -98,7 +99,7 @@ class ObjGraphTemplateTests(TestCase):
                 0,
                 self.pid,
                 ["test3"],
-                self.filename,
+                f"{dirname}{self.filename}",
                 d,
             )
             self.assertEqual(1, len(os.listdir(d)), os.listdir(d))
@@ -108,7 +109,6 @@ class ObjGraphTemplateTests(TestCase):
         handler = mock_fifo()
         output_bytes = pickle.dumps(self.items)
         handler.write.assert_called_with(output_bytes)
-        dirname = os.path.dirname(os.path.abspath(self.filename))
         self.assertEqual(
             self.items,
             [
@@ -118,8 +118,8 @@ class ObjGraphTemplateTests(TestCase):
                     "ast._things.test3",
                     10,
                     1024,
-                    f"{dirname}/ref_1234_test3.png",
-                    f"{dirname}/backref_1234_test3.png",
+                    f"{dirname}ref_1234_test3.png",
+                    f"{dirname}backref_1234_test3.png",
                 ],
             ],
         )


### PR DESCRIPTION
The .png files do not show up correctly in the memory_analyzer_out/ directory (as reported in
https://github.com/facebookincubator/memory-analyzer/issues/17).

This is because output_file does not have an explicit root and without it the absolute path is assumed to start with the cwd. The templates file can exist in a different path from the output directory, so the file can end up in a different location. Setting the output path before entering the templates file fixes this issue. This should also solve the issue of permission denied errors for creation of the png files.